### PR TITLE
Some old links now linked to the new repository

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,3 +20,4 @@ venv/
 
 
 papers/
+.vscode/

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 Repository for Robot Applications created as part of the [Computational Lexicology & Terminology Lab (CLTL)](http://www.cltl.nl) at the Vrije Universiteit, Amsterdam.
 
-![Pepper Robot Leolani](https://github.com/cltl/pepper/blob/develop/docs/images/pepper.png)
+![Pepper Robot Leolani](https://github.com/cltl-leolani/pepper/blob/develop/docs/images/pepper.png)
 
 ## Features
  - A framework for creating interactive Robot Applications using Python, to enable:
@@ -15,9 +15,9 @@ Repository for Robot Applications created as part of the [Computational Lexicolo
  - Realtime visualisation in web browser
 
 ## Getting started
-Check out our [WIKI](https://github.com/cltl/pepper/wiki) for information on [how it works](https://github.com/cltl/pepper/wiki/2.-How-it-works) and [how to set up](https://github.com/cltl/pepper/wiki/1.-Set-up).
+Check out our [WIKI](https://github.com/cltl-leolani/pepper/wiki) for information on [how it works](https://github.com/cltl-leolani/pepper/wiki/2.-How-it-works) and [how to set up](https://github.com/cltl-leolani/pepper/wiki/1.-Set-up).
 
-Check out our [API Reference](https://cltl.github.io/pepper/) and [Sample Applications](https://github.com/cltl/pepper/tree/develop/apps/examples)!
+Check out our [API Reference](https://cltl.github.io/pepper/) and [Sample Applications](https://github.com/cltl-leolani/pepper/tree/develop/apps/examples)!
 
 ## More information
 More information on the Pepper project at CLTL can be found on http://makerobotstalk.nl


### PR DESCRIPTION
Should the link [API Reference](https://cltl.github.io/pepper/) also be modified?